### PR TITLE
Add ID for C920

### DIFF
--- a/C920e.py
+++ b/C920e.py
@@ -8,6 +8,7 @@ import usb.core
 ACTIVATE_MIC = [1]
 DEACTIVATE_MIC = [0]
 SUPPORTED_CAMERA_IDS = {
+    0x082d: "Logi Webcam C920",
     0x08b6: "Logi Webcam C920e",
     0x085b: "Logi Webcam C925e",
 }


### PR DESCRIPTION
This worked for my non-e C920, here is the corresponding device ID from my hardware. Thanks for figuring this out and publishing this script, super useful for those of us without regular Windows access.